### PR TITLE
Use Grunt 0.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "JavaScript port of Ash framework",
     "private": true,
     "dependencies" : {
-        "grunt": "latest",
-        "grunt-requirejs": "latest"
+        "grunt": "0.3.x",
+        "grunt-requirejs": "0.3.x"
     },
     "scripts": {
         "grunt": "node_modules/.bin/grunt"


### PR DESCRIPTION
Just an hour ago, Grunt 0.4 was released. This make the package.json & grunt.js not working anymore. Forced to use Grunt 0.3.X until this is solved
