### PR TITLE
Simplify node definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ash-framework",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "JavaScript port of Ash framework",
     "private": true,
     "devDependencies" : {

--- a/src/ash/ash-framework.js
+++ b/src/ash/ash-framework.js
@@ -5,7 +5,7 @@
  */
 define(function (require) {
     var core = {
-        VERSION: '0.1.0'
+        VERSION: '0.2.0'
     };
 
     core.Engine = require('ash-core/engine');

--- a/src/ash/core/node.js
+++ b/src/ash/core/node.js
@@ -10,9 +10,51 @@ define([
         entity: null,
         previous: null,
         next: null,
-        
+
         constructor: function () { }
     });
+
+    /**
+    * A simpler way to create a node.
+    *
+    * Example: creating a node for component classes Point &amp; energy:
+    *
+    * var PlayerNode = Ash.Node.create({
+    *   point: Point,
+    *   energy: Energy
+    * });
+    *
+    * This is the simpler version from:
+    *
+    * var PlayerNode = Ash.Node.extend({
+    *   point: null,
+    *   energy: null,
+    *
+    *   types: {
+    *     point: Point,
+    *     energy: Energy
+    *   }
+    * });
+    */
+    Node.create = function (schema) {
+        var processedSchema = {
+            types: {},
+            constructor: function () { }
+        };
+
+        // process schema
+        for (var propertyName in schema) {
+            if (schema.hasOwnProperty(propertyName)) {
+                var propertyType = schema[propertyName];
+                if (propertyType) {
+                    processedSchema.types[propertyName] = propertyType;
+                }
+                processedSchema[propertyName] = null;
+            }
+        }
+
+        return Node.extend(processedSchema);
+    };
 
     return Node;
 });

--- a/test/spec/componentmatchingfamily.js
+++ b/test/spec/componentmatchingfamily.js
@@ -11,12 +11,8 @@ define ([
     var engine, family;
 
     // prepare MockNode
-    var MockNode = Ash.Node.extend({
-        point: null,
-        types: {
-            point: Point
-        },
-        constructor: function () { }
+    var MockNode = Ash.Node.create({
+        point: Point
     });
 
     module("Test Component Matching Family", {

--- a/test/spec/engine.js
+++ b/test/spec/engine.js
@@ -12,12 +12,25 @@ define ([
     // prepare MockNodes
     var MockNode = Ash.Node.extend({
         point: null,
-        constructor: function () { }
+        types: {
+            point: Point
+        },
+        constructor: function (x, y) {
+            x = x || 0;
+            y = y || 0;
+            this.point = new Point(x, y);
+        }
     });
 
     var MockNode2 = MockNode.extend({
+        point: null,
         matrix: null,
-        constructor: function () { }
+        types: {
+            point: Point
+        },
+        constructor: function () {
+            MockNode.super.constructor.call(this);
+        }
     });
 
     var MockFamily = Ash.Family.extend({

--- a/test/spec/nodelist.js
+++ b/test/spec/nodelist.js
@@ -2,16 +2,23 @@
  * Testing NodeList
  */
 define ([
-    'ash-framework'
-], function(Ash) {
+    'ash-framework',
+    'point'
+], function(Ash, Point) {
     'use strict';
 
     var nodes, tempNode;
 
     // prepare mock node
     var MockNode = Ash.Node.extend({
-        constructor: function (value) {
-            this.pos = value || 0;
+        point: null,
+        types: {
+            point: Point
+        },
+        constructor: function (x, y) {
+            x = x || 0;
+            y = y || 0;
+            this.point = new Point(x, y);
         }
     });
 
@@ -198,10 +205,10 @@ define ([
     });
 
     test("insertionSortCorrectlySortsSortedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0);
         nodes.add( node1 );
         nodes.add( node2 );
         nodes.add( node3 );
@@ -211,10 +218,10 @@ define ([
     });
 
     test("insertionSortCorrectlySortsReversedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0);
         nodes.add( node4 );
         nodes.add( node3 );
         nodes.add( node2 );
@@ -224,11 +231,11 @@ define ([
     });
 
     test("insertionSortCorrectlySortsMixedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 ),
-            node5 = new MockNode( 5 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0),
+            node5 = new MockNode(5, 0);
         nodes.add( node3 );
         nodes.add( node4 );
         nodes.add( node1 );
@@ -239,11 +246,11 @@ define ([
     });
 
     test("insertionSortRetainsTheOrderOfEquivalentNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 ),
-            node5 = new MockNode( 4 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0),
+            node5 = new MockNode(4, 0);
         nodes.add( node3 );
         nodes.add( node4 );
         nodes.add( node1 );
@@ -254,10 +261,10 @@ define ([
     });
 
     test("mergeSortCorrectlySortsSortedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0);
         nodes.add( node1 );
         nodes.add( node2 );
         nodes.add( node3 );
@@ -267,10 +274,10 @@ define ([
     });
 
     test("mergeSortCorrectlySortsReversedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0);
         nodes.add( node4 );
         nodes.add( node3 );
         nodes.add( node2 );
@@ -280,11 +287,11 @@ define ([
     });
 
     test("mergeSortCorrectlySortsMixedNodes", function() {
-        var node1 = new MockNode( 1 ),
-            node2 = new MockNode( 2 ),
-            node3 = new MockNode( 3 ),
-            node4 = new MockNode( 4 ),
-            node5 = new MockNode( 5 );
+        var node1 = new MockNode(1, 0),
+            node2 = new MockNode(2, 0),
+            node3 = new MockNode(3, 0),
+            node4 = new MockNode(4, 0),
+            node5 = new MockNode(5, 0);
         nodes.add( node3 );
         nodes.add( node4 );
         nodes.add( node1 );
@@ -295,7 +302,8 @@ define ([
     });
 
     function sortFunction( node1, node2 ) {
-        return node1.pos - node2.pos;
+        // sort based on x value
+        return node1.point.x - node2.point.x;
     }
 
     function testNodeOrder( nodes, nodeArray ) {


### PR DESCRIPTION
I'm proposing a simpler way to define a node using Node.create()

Example: creating a node for component classes Point & energy:

``` javascript
var PlayerNode = Ash.Node.create({
    point: Point,
    energy: Energy
});
```

This has the same effect as:

``` javascript
var PlayerNode = Ash.Node.extend({
    point: null,
    energy: null,

    types: {
        point: Point,
        energy: Energy
    }
});
```

I tested it on `ashjs-asteroids-example` (on branch `simple-nodes`) and it works so far. See the commits at https://github.com/abiyasa/ashjs-asteroids-example/commit/f7ed62b397a5f246511b0162b0555fd7d141cfdf
